### PR TITLE
Fixes/Additions

### DIFF
--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/Cenotaph.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/Cenotaph.java
@@ -280,7 +280,7 @@ public class Cenotaph extends JavaPlugin {
 			while (scanner.hasNextLine()) {
 				String line = scanner.nextLine().trim();
 				String[] split = line.split(":");
-				//block:lblock:sign:owner:level:time:lwc
+				//block:lblock:sign:owner:level:time:lwc:locketteSign
 				Block block = readBlock(split[0]);
 				Block lBlock = readBlock(split[1]);
 				Block sign = readBlock(split[2]);

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/Cenotaph.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/Cenotaph.java
@@ -41,6 +41,7 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.Sign;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -287,17 +288,27 @@ public class Cenotaph extends JavaPlugin {
 				int level = Integer.valueOf(split[4]);
 				long time = Long.valueOf(split[5]);
 				boolean lwc = Boolean.valueOf(split[6]);
-
+				Block locketteSign;
+				if (split.length == 7) {
+					// hack to allow old db files to still be usable
+					locketteSign = null;
+					continue;
+				} else {				
+					locketteSign = readBlock(split[7]);
+				}
+				
 				if (block == null || owner == null) {
 					log.info("[Cenotaph] Invalid entry in database " + fh.getName());
 					continue;
 				}
-				TombBlock tBlock = new TombBlock(block, lBlock, sign, owner, level, time, lwc);
+				
+				TombBlock tBlock = new TombBlock(block, lBlock, sign, owner, level, time, lwc, locketteSign);
 				tombList.offer(tBlock);
 				// Used for quick tombStone lookup
 				tombBlockList.put(block.getLocation(), tBlock);
 				if (lBlock != null) tombBlockList.put(lBlock.getLocation(), tBlock);
 				if (sign != null) tombBlockList.put(sign.getLocation(), tBlock);
+				if (locketteSign != null) tombBlockList.put(locketteSign.getLocation(), tBlock);
 				ArrayList<TombBlock> pList = playerTombList.get(owner);
 				if (pList == null) {
 					pList = new ArrayList<TombBlock>();
@@ -336,6 +347,8 @@ public class Cenotaph extends JavaPlugin {
 				bw.append(String.valueOf(tBlock.getTime()));
 				bw.append(":");
 				bw.append(String.valueOf(tBlock.getLwcEnabled()));
+				bw.append(":");
+				bw.append(printBlock(tBlock.getLocketteSign()));
 
 				bw.append(builder.toString());
 				bw.newLine();
@@ -347,7 +360,7 @@ public class Cenotaph extends JavaPlugin {
 	}
 
 	private String printBlock(Block b) {
-		if (b == null) return "";
+		if (b == null) return null;
 		return b.getWorld().getName() + "," + b.getX() + "," + b.getY() + "," + b.getZ();
 	}
 
@@ -360,6 +373,7 @@ public class Cenotaph extends JavaPlugin {
 		return world.getBlockAt(Integer.valueOf(split[1]), Integer.valueOf(split[2]), Integer.valueOf(split[3]));
 	}
 
+	
 	@Override
 	public void onDisable() {
 		for (World w : getServer().getWorlds()) saveCenotaphList(w.getName());
@@ -427,7 +441,7 @@ public class Cenotaph extends JavaPlugin {
 	}
 	public void deactivateLockette(TombBlock tBlock) {
 		if (tBlock.getLocketteSign() == null) return;
-		tBlock.getLocketteSign().getBlock().setType(Material.AIR);
+		tBlock.getLocketteSign().setType(Material.AIR);
 		tBlock.removeLocketteSign();
 	}
 

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphBlockListener.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphBlockListener.java
@@ -64,7 +64,7 @@ public class CenotaphBlockListener implements Listener {
 
 
 	//Handle Explosions...
-	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.HIGH)
 	public void onEntityExplode(EntityExplodeEvent event) {
 		Iterator<Block> iter = event.blockList().iterator();
 		while (iter.hasNext()) {
@@ -90,10 +90,10 @@ public class CenotaphBlockListener implements Listener {
 			//	plugin.getLogger().info("Protecting Cenotaph from the explosion!");
 				iter.remove();
 			}
-			else {
+			else if (event.isCancelled()) {
 			//	plugin.getLogger().info("Removing Cenotaph from the list");
 				plugin.removeTomb(tBlock, true);
-			}
+			} else return;
 		}
 	}
 }

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphCommand.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphCommand.java
@@ -35,7 +35,12 @@ public class CenotaphCommand implements CommandExecutor {
 			for (TombBlock tomb : pList) {
 				i++;
 				if (tomb.getBlock() == null) continue;
-				plugin.sendMessage(p, " " + i + " - World: " + tomb.getBlock().getWorld().getName() + " @(" + tomb.getBlock().getX() + "," + tomb.getBlock().getY() + "," + tomb.getBlock().getZ() + ")");
+				String message;
+				message = " " + i + " - World: " + tomb.getBlock().getWorld().getName() + " @(" + tomb.getBlock().getX() + "," + tomb.getBlock().getY() + "," + tomb.getBlock().getZ() + ")";
+				if (tomb.getLocketteSign() != null) {
+					message = message + " [Locked]";
+				}
+				plugin.sendMessage(p, message);
 			}
 			return true;
 		} else if (cmd.equalsIgnoreCase("cenfind")) {

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphCommand.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphCommand.java
@@ -32,15 +32,15 @@ public class CenotaphCommand implements CommandExecutor {
 			}
 			plugin.sendMessage(p, "Cenotaph List:");
 			int i = 0;
+			long cTime = System.currentTimeMillis() / 1000;
 			for (TombBlock tomb : pList) {
 				i++;
 				if (tomb.getBlock() == null) continue;
 				String message;
 				message = " " + i + " - World: " + tomb.getBlock().getWorld().getName() + " @(" + tomb.getBlock().getX() + "," + tomb.getBlock().getY() + "," + tomb.getBlock().getZ() + ")";
 				if (tomb.getLocketteSign() != null) {
-					message = message + " [Locked]";
-				}
-				plugin.sendMessage(p, message);
+					message = message + " [Locked " + plugin.convertTime( (int) (plugin.securityTimeout - (cTime - tomb.getTime())) ) + "]";
+				}				
 			}
 			return true;
 		} else if (cmd.equalsIgnoreCase("cenfind")) {

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphCommand.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphCommand.java
@@ -41,6 +41,7 @@ public class CenotaphCommand implements CommandExecutor {
 				if (tomb.getLocketteSign() != null) {
 					message = message + " [Locked " + plugin.convertTime( (int) (plugin.securityTimeout - (cTime - tomb.getTime())) ) + "]";
 				}				
+				plugin.sendMessage(p, message);
 			}
 			return true;
 		} else if (cmd.equalsIgnoreCase("cenfind")) {

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphEntityListener.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphEntityListener.java
@@ -374,7 +374,7 @@ public class CenotaphEntityListener implements Listener {
 				sign.update();
 			}
 		});
-		tBlock.setLocketteSign(sign);
+		tBlock.setLocketteSign(signBlock);
 		return true;
 	}
 

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphEntityListener.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphEntityListener.java
@@ -82,7 +82,7 @@ public class CenotaphEntityListener implements Listener {
 		}
 	}
 
-	@EventHandler
+	@EventHandler(priority = EventPriority.LOWEST)
 	public void onEntityDeath(EntityDeathEvent event)
 	{
 		if (!(event.getEntity() instanceof Player)) return;
@@ -293,7 +293,7 @@ public class CenotaphEntityListener implements Listener {
 		msg += ChatColor.YELLOW + "Security: " + ChatColor.WHITE;
 		if (prot) {
 			msg += (protLWC ? "LWC" : "Lockette") + " ";
-			if (plugin.securityRemove) msg += ChatColor.YELLOW + "SecTime: " + ChatColor.WHITE + (plugin.securityTimeout < breakTime && plugin.cenotaphRemove && !plugin.keepUntilEmpty ? plugin.convertTime(plugin.securityTimeout) : "Inf" ) + " ";
+			if (plugin.securityRemove) msg += ChatColor.YELLOW + "SecTime: " + ChatColor.WHITE + plugin.convertTime(plugin.securityTimeout) + " ";
 		}
 		else msg += "None ";
 		msg += ChatColor.YELLOW + "BreakTime: " + ChatColor.WHITE + (plugin.cenotaphRemove ? plugin.convertTime(breakTime) : "Inf") + " ";

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/TombBlock.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/TombBlock.java
@@ -7,7 +7,7 @@ public class TombBlock {
 	private Block block;
 	private Block lBlock;
 	private Block sign;
-	private Sign LocketteSign;
+	private Block locketteSign;
 	private long time;
 	private String owner;
 	private int ownerLevel;
@@ -21,7 +21,7 @@ public class TombBlock {
 		this.ownerLevel = ownerLevel;
 		this.time = time;
 	}
-	TombBlock(Block block, Block lBlock, Block sign, String owner, int ownerLevel, long time, boolean lwc) {
+	TombBlock(Block block, Block lBlock, Block sign, String owner, int ownerLevel, long time, boolean lwc, Block locketteSign) {
 		this.block = block;
 		this.lBlock = lBlock;
 		this.sign = sign;
@@ -29,6 +29,7 @@ public class TombBlock {
 		this.ownerLevel = ownerLevel;
 		this.time = time;
 		this.lwcEnabled = lwc;
+		this.locketteSign = locketteSign;
 	}
 
 	long getTime() {
@@ -43,8 +44,8 @@ public class TombBlock {
 	Block getSign() {
 		return sign;
 	}
-	Sign getLocketteSign() {
-		return LocketteSign;
+	Block getLocketteSign() {
+		return locketteSign;
 	}
 	String getOwner() {
 		return owner;
@@ -58,10 +59,10 @@ public class TombBlock {
 	void setLwcEnabled(boolean val) {
 		lwcEnabled = val;
 	}
-	void setLocketteSign(Sign sign) {
-		this.LocketteSign = sign;
+	void setLocketteSign(Block signBlock) {
+		this.locketteSign = signBlock;
 	}
 	void removeLocketteSign() {
-		this.LocketteSign = null;
+		this.locketteSign = null;
 	}
 }


### PR DESCRIPTION
Fixes: 
- Add locketteSign to saving and loading in tombBlock database, fixes auto-unlocking chests.
- Fix explosions destroying chests before lockette/deadbolt signs can be placed.
- Fix for lock time-out not showing properly on the message sent to players who just died and made a deathchest.
- Fix for explosion-deaths' cenotaphs not being saved to the database.

Additions:
- Add indicator to /cenlist displaying [Locked] status if locketteSign is still present on cenotaph.
- Show remaining locked time on /cenlist command.
