### PR TITLE
LlmDl's 1.14 update to Cenotaph.

### DIFF
--- a/README
+++ b/README
@@ -102,6 +102,16 @@ LlmDl: making lockette support all it should be
 =============
  Changes
 =============
+[Version 5.1]
+  - Update to much of the Lockette/Sign code to make it not use deprecated API.
+  - Update to use UUIDs in TombBlocks, allowing us to use less deprecated methods.
+  - Update to pom.xml's sk89q's repos, making them not be required in the lib folder.
+  - Update to economy handler, no longer errors when Vault is not found on a server.
+  - Old databases will have old tombstones which do not have ownerUUID
+    values. These will be null, and means that for those tombstones there
+    will be no message sent to a player when their security runs out/they
+    have their tombstone destroyed, (but these messages wouldn't be shown
+    anyways if this happened while they were offline.)
 [Version 5.0]
   - Recompiled for 1.14.4
 [Version 4.9]

--- a/README
+++ b/README
@@ -88,7 +88,7 @@ See default config file for options and instructions.
 To Build yourself
 ==============
 Download BuildTools and Build 1.14 Spigot.
-Get 1.14 versions of WorldEdit and WorldGuard and LWC to the lib folder and build with Maven
+Get 1.14 version of LWC into the lib folder and build with Maven
 
 =============
  Credits

--- a/README
+++ b/README
@@ -87,8 +87,9 @@ See default config file for options and instructions.
 ==============
 To Build yourself
 ==============
-Download BuildTools and Build 1.14 Spigot.
-Get 1.14 version of LWC into the lib folder and build with Maven
+
+Convert to Maven Project and right click pom.xml > run as Maven Install.
+All dependencies should be located at their respective repos.
 
 =============
  Credits

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>MoofIT</groupId>
     <artifactId>Cenotaph</artifactId>
-    <version>5.0</version>
+    <version>5.1</version>
 
     <repositories>
         <repository>
@@ -26,18 +26,9 @@
             <url>http://repo.mikeprimm.com</url>
         </repository>
         <repository>
-            <id>dmulloy2</id>
-            <url>http://repo.dmulloy2.net/nexus/repository/snapshots/</url>
+        	<id>minebench-lwc-hookup</id>
+        	<url>https://repo.minebench.de</url>
         </repository>
-      <!--  <repository>
-            <id>LWC</id>
-            <url>http://andune.com/nexus/content/repositories/public</url>
-        </repository>-->
-        <repository>
-            <id>localLWCrepository</id>
-            <url>file://${basedir}/lib</url>
-        </repository>
-
     </repositories>
 
 
@@ -48,22 +39,11 @@
             <version>1.14.4-R0.1-SNAPSHOT</version>
             <type>jar</type>
         </dependency>
-<!--        <dependency>
-            <groupId>com.griefcraft</groupId>
-            <artifactId>LWC</artifactId>
-            <version>4.5.0-SNAPSHOT</version>
-            <type>jar</type>
-            <scope>system</scope>
-            <systemPath>${basedir}/lib/Modern-LWC-2.1.4-dev.jar</systemPath>
-
-        </dependency>-->
         <dependency>
             <groupId>com.griefcraft</groupId>
-            <artifactId>LWC</artifactId>
-            <version>4.7.0-SNAPSHOT</version>
-            <scope>system</scope>
-            <systemPath>${basedir}/lib/lwc-4.7.0-SNAPSHOT.jar</systemPath>
-            <type>jar</type>
+            <artifactId>lwc</artifactId>
+    		<version>4.7.0-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>us.dynmap</groupId>
@@ -80,18 +60,14 @@
             <groupId>com.sk89q.worldguard</groupId>
             <artifactId>worldguard-legacy</artifactId>
             <version>7.0.0-SNAPSHOT</version>
-            <type>jar</type>
-            <scope>system</scope>
-            <systemPath>${basedir}/lib/worldguard-legacy-7.0.0-SNAPSHOT-dist (7).jar</systemPath>
+            <scope>provided</scope>
         </dependency>
-        <!--WorldGuard depends on WorldEdit-->
+
         <dependency>
             <groupId>com.sk89q.worldedit</groupId>
             <artifactId>worldedit-bukkit</artifactId>
-            <version>7.0.0-SNAPSHOT</version>
-            <type>jar</type>
-            <scope>system</scope>
-            <systemPath>${basedir}/lib/worldedit-bukkit-7.0.0-SNAPSHOT-dist (6).jar</systemPath>
+            <version>7.1.0-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,15 +48,6 @@
             <version>1.14.4-R0.1-SNAPSHOT</version>
             <type>jar</type>
         </dependency>
-<!--        <dependency>
-            <groupId>com.griefcraft</groupId>
-            <artifactId>LWC</artifactId>
-            <version>4.5.0-SNAPSHOT</version>
-            <type>jar</type>
-            <scope>system</scope>
-            <systemPath>${basedir}/lib/Modern-LWC-2.1.4-dev.jar</systemPath>
-
-        </dependency>-->
         <dependency>
             <groupId>com.griefcraft</groupId>
             <artifactId>LWC</artifactId>
@@ -80,18 +71,14 @@
             <groupId>com.sk89q.worldguard</groupId>
             <artifactId>worldguard-legacy</artifactId>
             <version>7.0.0-SNAPSHOT</version>
-            <type>jar</type>
-            <scope>system</scope>
-            <systemPath>${basedir}/lib/worldguard-legacy-7.0.0-SNAPSHOT-dist (7).jar</systemPath>
+            <scope>provided</scope>
         </dependency>
-        <!--WorldGuard depends on WorldEdit-->
+
         <dependency>
             <groupId>com.sk89q.worldedit</groupId>
             <artifactId>worldedit-bukkit</artifactId>
-            <version>7.0.0-SNAPSHOT</version>
-            <type>jar</type>
-            <scope>system</scope>
-            <systemPath>${basedir}/lib/worldedit-bukkit-7.0.0-SNAPSHOT-dist (6).jar</systemPath>
+            <version>7.1.0-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>MoofIT</groupId>
     <artifactId>Cenotaph</artifactId>
-    <version>5.0</version>
+    <version>5.1</version>
 
     <repositories>
         <repository>
@@ -29,10 +29,6 @@
             <id>dmulloy2</id>
             <url>http://repo.dmulloy2.net/nexus/repository/snapshots/</url>
         </repository>
-      <!--  <repository>
-            <id>LWC</id>
-            <url>http://andune.com/nexus/content/repositories/public</url>
-        </repository>-->
         <repository>
             <id>localLWCrepository</id>
             <url>file://${basedir}/lib</url>

--- a/pom.xml
+++ b/pom.xml
@@ -26,14 +26,9 @@
             <url>http://repo.mikeprimm.com</url>
         </repository>
         <repository>
-            <id>dmulloy2</id>
-            <url>http://repo.dmulloy2.net/nexus/repository/snapshots/</url>
+        	<id>minebench-lwc-hookup</id>
+        	<url>https://repo.minebench.de</url>
         </repository>
-        <repository>
-            <id>localLWCrepository</id>
-            <url>file://${basedir}/lib</url>
-        </repository>
-
     </repositories>
 
 
@@ -46,11 +41,9 @@
         </dependency>
         <dependency>
             <groupId>com.griefcraft</groupId>
-            <artifactId>LWC</artifactId>
-            <version>4.7.0-SNAPSHOT</version>
-            <scope>system</scope>
-            <systemPath>${basedir}/lib/lwc-4.7.0-SNAPSHOT.jar</systemPath>
-            <type>jar</type>
+            <artifactId>lwc</artifactId>
+    		<version>4.7.0-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>us.dynmap</groupId>

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/Cenotaph.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/Cenotaph.java
@@ -355,7 +355,7 @@ public class Cenotaph extends JavaPlugin {
 					continue;
 				}
 				
-				TombBlock tBlock = new TombBlock(block, lBlock, sign, owner, ownerUUID, level, time, lwc, locketteSign);
+				TombBlock tBlock = new TombBlock(block, lBlock, sign, owner, level, time, lwc, locketteSign, ownerUUID);
 				tombList.offer(tBlock);
 				// Used for quick tombStone lookup
 				tombBlockList.put(block.getLocation(), tBlock);
@@ -402,6 +402,8 @@ public class Cenotaph extends JavaPlugin {
 				bw.append(String.valueOf(tBlock.getLwcEnabled()));
 				bw.append(":");
 				bw.append(printBlock(tBlock.getLocketteSign()));
+				bw.append(":");
+				bw.append(String.valueOf(tBlock.getOwnerUUID()));
 
 				bw.append(builder.toString());
 				bw.newLine();

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/Cenotaph.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/Cenotaph.java
@@ -19,29 +19,25 @@ package com.MoofIT.Minecraft.Cenotaph;
  * along with this program.If not, see <http://www.gnu.org/licenses/>.
  */
 
-import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Scanner;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.logging.Logger;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
-import org.bukkit.block.Sign;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -116,6 +112,7 @@ public class Cenotaph extends JavaPlugin {
 	public boolean oneBlockUp = true;
 	public boolean creeperProtection = false;
 	public boolean tntProtection = false;
+	public static boolean economyEnabled = false;
 	public String signMessage[] = new String[] {
 		"{name}",
 		"RIP",
@@ -171,7 +168,7 @@ public class Cenotaph extends JavaPlugin {
 		lwcPlugin = (LWCPlugin)loadPlugin("LWC");
 		dynmap = (DynmapAPI)loadPlugin("dynmap");
 
-		setupEconomy();
+		economyEnabled = setupEconomy();
 		
 		initDeathMessagesDefaults();
 		loadConfig();
@@ -190,11 +187,14 @@ public class Cenotaph extends JavaPlugin {
 
     private boolean setupEconomy()
     {
-        RegisteredServiceProvider<Economy> economyProvider = getServer().getServicesManager().getRegistration(net.milkbowl.vault.economy.Economy.class);
-        if (economyProvider != null) {
-            econ = economyProvider.getProvider();
+    	if (Bukkit.getServer().getPluginManager().isPluginEnabled("Vault")) {
+	        RegisteredServiceProvider<Economy> economyProvider = getServer().getServicesManager().getRegistration(net.milkbowl.vault.economy.Economy.class);
+	        if (economyProvider != null)
+	            econ = economyProvider.getProvider();
+	        	return (econ != null);
+        } else {
+        	return false;
         }
-        return (econ != null);
     }
 	
 	public void loadConfig() {
@@ -229,13 +229,9 @@ public class Cenotaph extends JavaPlugin {
 		worldguardSupport = config.getBoolean("Core.worldguardSupport", worldguardSupport);
 		moneyTake = (float) config.getDouble("Core.moneyTake", moneyTake);
 		
-	    if (moneyTake > 0){
-	    	if (getServer().getPluginManager().getPlugin("Vault") == null || econ == null) {
-	    		log.severe(String.format("[%s] - Make sure you have both Vault and an Economy plugin installed. Money will NOT be taken on cenotaph creation.", getDescription().getName()));
-	    		moneyTake = 0;
-	    		//getServer().getPluginManager().disablePlugin(this);
-	    		//return;
-	    	}
+	    if (moneyTake > 0 && !economyEnabled){
+    		log.severe(String.format("[%s] - Make sure you have both Vault and an Economy plugin installed. Money will NOT be taken on cenotaph creation.", getDescription().getName()));
+    		moneyTake = 0;
 	    }
 	    
 	    if (worldguardSupport){
@@ -334,11 +330,12 @@ public class Cenotaph extends JavaPlugin {
 				Block block = readBlock(split[0]);
 				Block lBlock = readBlock(split[1]);
 				Block sign = readBlock(split[2]);
-				String owner = split[3];
+				String owner = split[3];				
 				int level = Integer.valueOf(split[4]);
 				long time = Long.valueOf(split[5]);
 				boolean lwc = Boolean.valueOf(split[6]);
 				Block locketteSign;
+				UUID ownerUUID;
 				if (split.length == 7) {
 					// hack to allow old db files to still be usable
 					locketteSign = null;
@@ -346,13 +343,19 @@ public class Cenotaph extends JavaPlugin {
 				} else {				
 					locketteSign = readBlock(split[7]);
 				}
+				if (split.length == 8) {
+					ownerUUID = null;
+					continue;
+				} else {
+					ownerUUID = UUID.fromString(split[8]);
+				}
 				
 				if (block == null || owner == null) {
 					log.info("[Cenotaph] Invalid entry in database " + fh.getName());
 					continue;
 				}
 				
-				TombBlock tBlock = new TombBlock(block, lBlock, sign, owner, level, time, lwc, locketteSign);
+				TombBlock tBlock = new TombBlock(block, lBlock, sign, owner, ownerUUID, level, time, lwc, locketteSign);
 				tombList.offer(tBlock);
 				// Used for quick tombStone lookup
 				tombBlockList.put(block.getLocation(), tBlock);
@@ -600,7 +603,9 @@ public class Cenotaph extends JavaPlugin {
 
 		removeTomb(tBlock, true);
 
-		Player p = getServer().getPlayer(tBlock.getOwner());
+		Player p = null;
+		if (tBlock.getOwnerUUID() != null)
+			p = getServer().getPlayer(tBlock.getOwnerUUID());
 		if (p != null) sendMessage(p, "Your cenotaph has broken.");
 	}
 

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphBlockListener.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphBlockListener.java
@@ -4,6 +4,8 @@ import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Directional;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -24,11 +26,20 @@ public class CenotaphBlockListener implements Listener {
 	public void onBlockBreak(BlockBreakEvent event) {
 		Block b = event.getBlock();
 		Player p = event.getPlayer();
+		
 
+		
+		// Handles wall_signs which are used for lockette/deadbolt locks on Tombstones.
 		if ( Tag.WALL_SIGNS.isTagged( b.getType() ) )
 		{
-			org.bukkit.material.Sign signData = (org.bukkit.material.Sign)b.getState().getData();
-			TombBlock tBlock = Cenotaph.tombBlockList.get(b.getRelative(signData.getAttachedFace()).getLocation());
+			TombBlock tBlock = null;
+			BlockData blockData = b.getBlockData();
+			Directional directional = (Directional) blockData;
+			Block attachedBlock = b.getRelative(directional.getFacing().getOppositeFace());
+
+			if (attachedBlock != null)
+				tBlock = Cenotaph.tombBlockList.get(attachedBlock.getLocation());
+			
 			if (tBlock == null) return;
 
 			if (tBlock.getLocketteSign() != null) {
@@ -65,9 +76,11 @@ public class CenotaphBlockListener implements Listener {
 				plugin.sendMessage(p, "Cannot interfere with a locked Cenotaph.");
 				return;
 			}
-		}
+		}		
+		Player owner = null;
+		if (tBlock.getOwnerUUID() != null)
+			owner = plugin.getServer().getPlayer(tBlock.getOwnerUUID());
 		plugin.removeTomb(tBlock, true);
-		Player owner = plugin.getServer().getPlayer(tBlock.getOwner());
 		if (owner != null) plugin.sendMessage(owner, "Your cenotaph has been destroyed by " + p.getName() + "!");
 	}
 
@@ -80,8 +93,13 @@ public class CenotaphBlockListener implements Listener {
 			Block block = iter.next();
 
 			if (Tag.WALL_SIGNS.isTagged( block.getType())) {
-				org.bukkit.material.Sign signData = (org.bukkit.material.Sign) block.getState().getData();
-				TombBlock tBlock = Cenotaph.tombBlockList.get(block.getRelative(signData.getAttachedFace()).getLocation());
+				TombBlock tBlock = null;
+				BlockData blockData = block.getBlockData();				
+				Directional directional = (Directional) blockData;
+				Block attachedBlock = block.getRelative(directional.getFacing().getOppositeFace());
+
+				if (attachedBlock != null)
+					tBlock = Cenotaph.tombBlockList.get(attachedBlock.getLocation());
 				if (tBlock == null) {
 					continue;
 				}

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphCommand.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphCommand.java
@@ -15,6 +15,7 @@ public class CenotaphCommand implements CommandExecutor {
 		this.plugin = instance;
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
 		if (!(sender instanceof Player)) return false;

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphEntityListener.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphEntityListener.java
@@ -231,7 +231,7 @@ public class CenotaphEntityListener implements Listener {
 			removeSignCount -= 1;
 
 		// Create a TombBlock for this tombstone
-		TombBlock tBlock = new TombBlock(sChest.getBlock(), (lChest != null) ? lChest.getBlock() : null, sBlock, p.getName(), p.getUniqueId(), p.getLevel() + 1, (System.currentTimeMillis() / 1000));
+		TombBlock tBlock = new TombBlock(sChest.getBlock(), (lChest != null) ? lChest.getBlock() : null, sBlock, p.getName(), p.getLevel() + 1, (System.currentTimeMillis() / 1000), p.getUniqueId());
 
 		// Protect the chest/sign if LWC is installed.
 		Boolean prot = false;

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphEntityListener.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphEntityListener.java
@@ -40,8 +40,6 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.material.Directional;
-import org.bukkit.material.MaterialData;
 import com.griefcraft.lwc.LWC;
 import com.griefcraft.model.Protection;
 import net.milkbowl.vault.economy.EconomyResponse;
@@ -127,11 +125,14 @@ public class CenotaphEntityListener implements Listener {
 				return;
 			}
 		}
-		//Check balance
-		if (!p.hasPermission("cenotaph.nocost") && plugin.moneyTake > 0){
-		if (Cenotaph.econ.getBalance(p) < plugin.moneyTake){
-			plugin.sendMessage(p, "Not enough money! Inv dropped.");
-			return;
+		
+		if (Cenotaph.economyEnabled) {
+			//Check balance
+			if (!p.hasPermission("cenotaph.nocost") && plugin.moneyTake > 0){
+			if (Cenotaph.econ.getBalance(p) < plugin.moneyTake){
+				plugin.sendMessage(p, "Not enough money! Inv dropped.");
+				return;
+				}
 			}
 		}
 
@@ -230,7 +231,7 @@ public class CenotaphEntityListener implements Listener {
 			removeSignCount -= 1;
 
 		// Create a TombBlock for this tombstone
-		TombBlock tBlock = new TombBlock(sChest.getBlock(), (lChest != null) ? lChest.getBlock() : null, sBlock, p.getName(), p.getLevel() + 1, (System.currentTimeMillis() / 1000));
+		TombBlock tBlock = new TombBlock(sChest.getBlock(), (lChest != null) ? lChest.getBlock() : null, sBlock, p.getName(), p.getLevel() + 1, (System.currentTimeMillis() / 1000), p.getUniqueId());
 
 		// Protect the chest/sign if LWC is installed.
 		Boolean prot = false;
@@ -387,17 +388,13 @@ public class CenotaphEntityListener implements Listener {
 			return false;
 		}
 
-		signBlock.setType(Material.AIR); //hack to prevent oddness with signs popping out of the ground as of Bukkit 818
+
 		signBlock.setType(Material.OAK_WALL_SIGN);
-
-		BlockState signBlockState = null;
-		signBlockState = signBlock.getState();
-
-		MaterialData signFacingDirection = signBlockState.getData();
-		//BlockFace facing = getLocketteSignDirection(plugin.getYawTo(tBlock.getBlock().getLocation(), signBlock.getLocation()));
-        BlockFace facing = tBlock.getBlock().getFace(signBlock);
-		((Directional)signFacingDirection).setFacingDirection(facing);
-		signBlockState.setData(signFacingDirection);
+		BlockState signBlockState = signBlock.getState();
+		org.bukkit.block.data.type.WallSign signBlockData = (org.bukkit.block.data.type.WallSign) signBlockState.getBlockData();
+		BlockFace facing = tBlock.getBlock().getFace(signBlock);
+		signBlockData.setFacing(facing);
+		signBlockState.setBlockData(signBlockData);
 
 		final Sign sign = (Sign)signBlockState;
 
@@ -638,23 +635,6 @@ public class CenotaphEntityListener implements Listener {
 		exp = base.getWorld().getBlockAt(base.getX(), base.getY(), base.getZ() + 1);
 		if (exp.getType() == Material.CHEST) return true;
 		return false;
-	}
-	
-	private BlockFace getLocketteSignDirection(double rot) {
-
-		if (0 <= rot && rot < 45) {
-			return BlockFace.NORTH;
-		} else if (45 <= rot && rot < 135) {
-			return BlockFace.EAST;
-		} else if (135 <= rot && rot < 225) {
-			return BlockFace.SOUTH;
-		} else if (225 <= rot && rot < 315) {
-			return BlockFace.WEST;
-		} else if (315 <= rot && rot < 360) {
-			return BlockFace.NORTH;
-		} else {
-			return null;
-		}
 	}
 
 }

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphEntityListener.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphEntityListener.java
@@ -636,22 +636,5 @@ public class CenotaphEntityListener implements Listener {
 		if (exp.getType() == Material.CHEST) return true;
 		return false;
 	}
-	
-//	private BlockFace getLocketteSignDirection(double rot) {
-//
-//		if (0 <= rot && rot < 45) {
-//			return BlockFace.NORTH;
-//		} else if (45 <= rot && rot < 135) {
-//			return BlockFace.EAST;
-//		} else if (135 <= rot && rot < 225) {
-//			return BlockFace.SOUTH;
-//		} else if (225 <= rot && rot < 315) {
-//			return BlockFace.WEST;
-//		} else if (315 <= rot && rot < 360) {
-//			return BlockFace.NORTH;
-//		} else {
-//			return null;
-//		}
-//	}
 
 }

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphEntityListener.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphEntityListener.java
@@ -40,8 +40,6 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.material.Directional;
-import org.bukkit.material.MaterialData;
 import com.griefcraft.lwc.LWC;
 import com.griefcraft.model.Protection;
 import net.milkbowl.vault.economy.EconomyResponse;
@@ -127,11 +125,14 @@ public class CenotaphEntityListener implements Listener {
 				return;
 			}
 		}
-		//Check balance
-		if (!p.hasPermission("cenotaph.nocost") && plugin.moneyTake > 0){
-		if (Cenotaph.econ.getBalance(p) < plugin.moneyTake){
-			plugin.sendMessage(p, "Not enough money! Inv dropped.");
-			return;
+		
+		if (Cenotaph.economyEnabled) {
+			//Check balance
+			if (!p.hasPermission("cenotaph.nocost") && plugin.moneyTake > 0){
+			if (Cenotaph.econ.getBalance(p) < plugin.moneyTake){
+				plugin.sendMessage(p, "Not enough money! Inv dropped.");
+				return;
+				}
 			}
 		}
 
@@ -230,7 +231,7 @@ public class CenotaphEntityListener implements Listener {
 			removeSignCount -= 1;
 
 		// Create a TombBlock for this tombstone
-		TombBlock tBlock = new TombBlock(sChest.getBlock(), (lChest != null) ? lChest.getBlock() : null, sBlock, p.getName(), p.getLevel() + 1, (System.currentTimeMillis() / 1000));
+		TombBlock tBlock = new TombBlock(sChest.getBlock(), (lChest != null) ? lChest.getBlock() : null, sBlock, p.getName(), p.getUniqueId(), p.getLevel() + 1, (System.currentTimeMillis() / 1000));
 
 		// Protect the chest/sign if LWC is installed.
 		Boolean prot = false;
@@ -387,17 +388,13 @@ public class CenotaphEntityListener implements Listener {
 			return false;
 		}
 
-		signBlock.setType(Material.AIR); //hack to prevent oddness with signs popping out of the ground as of Bukkit 818
+
 		signBlock.setType(Material.OAK_WALL_SIGN);
-
-		BlockState signBlockState = null;
-		signBlockState = signBlock.getState();
-
-		MaterialData signFacingDirection = signBlockState.getData();
-		//BlockFace facing = getLocketteSignDirection(plugin.getYawTo(tBlock.getBlock().getLocation(), signBlock.getLocation()));
-        BlockFace facing = tBlock.getBlock().getFace(signBlock);
-		((Directional)signFacingDirection).setFacingDirection(facing);
-		signBlockState.setData(signFacingDirection);
+		BlockState signBlockState = signBlock.getState();
+		org.bukkit.block.data.type.WallSign signBlockData = (org.bukkit.block.data.type.WallSign) signBlockState.getBlockData();
+		BlockFace facing = tBlock.getBlock().getFace(signBlock);
+		signBlockData.setFacing(facing);
+		signBlockState.setBlockData(signBlockData);
 
 		final Sign sign = (Sign)signBlockState;
 
@@ -640,21 +637,21 @@ public class CenotaphEntityListener implements Listener {
 		return false;
 	}
 	
-	private BlockFace getLocketteSignDirection(double rot) {
-
-		if (0 <= rot && rot < 45) {
-			return BlockFace.NORTH;
-		} else if (45 <= rot && rot < 135) {
-			return BlockFace.EAST;
-		} else if (135 <= rot && rot < 225) {
-			return BlockFace.SOUTH;
-		} else if (225 <= rot && rot < 315) {
-			return BlockFace.WEST;
-		} else if (315 <= rot && rot < 360) {
-			return BlockFace.NORTH;
-		} else {
-			return null;
-		}
-	}
+//	private BlockFace getLocketteSignDirection(double rot) {
+//
+//		if (0 <= rot && rot < 45) {
+//			return BlockFace.NORTH;
+//		} else if (45 <= rot && rot < 135) {
+//			return BlockFace.EAST;
+//		} else if (135 <= rot && rot < 225) {
+//			return BlockFace.SOUTH;
+//		} else if (225 <= rot && rot < 315) {
+//			return BlockFace.WEST;
+//		} else if (315 <= rot && rot < 360) {
+//			return BlockFace.NORTH;
+//		} else {
+//			return null;
+//		}
+//	}
 
 }

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/TombBlock.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/TombBlock.java
@@ -15,7 +15,7 @@ public class TombBlock {
 	private boolean lwcEnabled = false;
 	private UUID ownerUUID;
 
-	TombBlock(Block block, Block lBlock, Block sign, String owner, UUID ownerUUID, int ownerLevel, long time) {
+	TombBlock(Block block, Block lBlock, Block sign, String owner, int ownerLevel, long time, UUID ownerUUID) {
 		this.block = block;
 		this.lBlock = lBlock;
 		this.sign = sign;
@@ -25,7 +25,7 @@ public class TombBlock {
 		this.time = time;
 		
 	}
-	TombBlock(Block block, Block lBlock, Block sign, String owner, UUID ownerUUID,  int ownerLevel, long time, boolean lwc, Block locketteSign) {
+	TombBlock(Block block, Block lBlock, Block sign, String owner,  int ownerLevel, long time, boolean lwc, Block locketteSign, UUID ownerUUID) {
 		this.block = block;
 		this.lBlock = lBlock;
 		this.sign = sign;

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/TombBlock.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/TombBlock.java
@@ -1,7 +1,8 @@
 package com.MoofIT.Minecraft.Cenotaph;
 
+import java.util.UUID;
+
 import org.bukkit.block.Block;
-import org.bukkit.block.Sign;
 
 public class TombBlock {
 	private Block block;
@@ -12,20 +13,24 @@ public class TombBlock {
 	private String owner;
 	private int ownerLevel;
 	private boolean lwcEnabled = false;
+	private UUID ownerUUID;
 
-	TombBlock(Block block, Block lBlock, Block sign, String owner, int ownerLevel, long time) {
+	TombBlock(Block block, Block lBlock, Block sign, String owner, UUID ownerUUID, int ownerLevel, long time) {
 		this.block = block;
 		this.lBlock = lBlock;
 		this.sign = sign;
 		this.owner = owner;
+		this.ownerUUID = ownerUUID;
 		this.ownerLevel = ownerLevel;
 		this.time = time;
+		
 	}
-	TombBlock(Block block, Block lBlock, Block sign, String owner, int ownerLevel, long time, boolean lwc, Block locketteSign) {
+	TombBlock(Block block, Block lBlock, Block sign, String owner, UUID ownerUUID,  int ownerLevel, long time, boolean lwc, Block locketteSign) {
 		this.block = block;
 		this.lBlock = lBlock;
 		this.sign = sign;
 		this.owner = owner;
+		this.ownerUUID = ownerUUID;
 		this.ownerLevel = ownerLevel;
 		this.time = time;
 		this.lwcEnabled = lwc;
@@ -49,6 +54,9 @@ public class TombBlock {
 	}
 	String getOwner() {
 		return owner;
+	}
+	UUID getOwnerUUID() {
+		return ownerUUID;
 	}
 	int getOwnerLevel() {
 		return ownerLevel;

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/TombBlock.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/TombBlock.java
@@ -1,7 +1,8 @@
 package com.MoofIT.Minecraft.Cenotaph;
 
+import java.util.UUID;
+
 import org.bukkit.block.Block;
-import org.bukkit.block.Sign;
 
 public class TombBlock {
 	private Block block;
@@ -12,20 +13,24 @@ public class TombBlock {
 	private String owner;
 	private int ownerLevel;
 	private boolean lwcEnabled = false;
+	private UUID ownerUUID;
 
-	TombBlock(Block block, Block lBlock, Block sign, String owner, int ownerLevel, long time) {
+	TombBlock(Block block, Block lBlock, Block sign, String owner, int ownerLevel, long time, UUID ownerUUID) {
 		this.block = block;
 		this.lBlock = lBlock;
 		this.sign = sign;
 		this.owner = owner;
+		this.ownerUUID = ownerUUID;
 		this.ownerLevel = ownerLevel;
 		this.time = time;
+		
 	}
-	TombBlock(Block block, Block lBlock, Block sign, String owner, int ownerLevel, long time, boolean lwc, Block locketteSign) {
+	TombBlock(Block block, Block lBlock, Block sign, String owner,  int ownerLevel, long time, boolean lwc, Block locketteSign, UUID ownerUUID) {
 		this.block = block;
 		this.lBlock = lBlock;
 		this.sign = sign;
 		this.owner = owner;
+		this.ownerUUID = ownerUUID;
 		this.ownerLevel = ownerLevel;
 		this.time = time;
 		this.lwcEnabled = lwc;
@@ -49,6 +54,9 @@ public class TombBlock {
 	}
 	String getOwner() {
 		return owner;
+	}
+	UUID getOwnerUUID() {
+		return ownerUUID;
 	}
 	int getOwnerLevel() {
 		return ownerLevel;

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/TombThread.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/TombThread.java
@@ -71,7 +71,7 @@ public class TombThread extends Thread {
 
 			//Security removal check
 			if (plugin.securityRemove) {
-				Player p = plugin.getServer().getPlayer(tBlock.getOwner());
+				Player p = plugin.getServer().getPlayer(tBlock.getOwnerUUID());
 
 				if (cTime >= (tBlock.getTime() + plugin.securityTimeout)) {
 					if (tBlock.getLwcEnabled() && plugin.lwcPlugin != null) {


### PR DESCRIPTION
- Update to much of the Lockette/Sign code to make it not use deprecated API.

- Update to use UUIDs in TombBlocks, allowing us to use less deprecated methods.

- Update to pom.xml's sk89q's repos & lwc repo, making them not be required in the lib folder.

- Update to economy handler, no longer errors when Vault is not found on a server.

- Old databases will have old tombstones which do not have ownerUUID values. These will be null, and means that for those tombstones there will be no message sent to a player when their security runs out/they have their tombstone destroyed, (but these messages wouldn't be shown anyways if this happened while they were offline.)

- I have tested this out quite a bit, but of course I may have missed a thing or two.

Anyone wishing to test this out may download it here: https://github.com/LlmDl/Cenotaph/releases/tag/5.1