### PR TITLE
Fix filtering versions in the plugin.yml.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,12 @@
 
     <groupId>MoofIT</groupId>
     <artifactId>Cenotaph</artifactId>
+    <packaging>jar</packaging>
     <version>5.1</version>
+    
+    <properties>
+        <project.bukkitAPIVersion>1.14</project.bukkitAPIVersion>
+    </properties>
 
     <repositories>
         <repository>
@@ -83,6 +88,13 @@
                 </configuration>
             </plugin>
         </plugins>
+        <sourceDirectory>src/main/java</sourceDirectory>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
     </build>
 
 

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphBlockListener.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphBlockListener.java
@@ -62,7 +62,7 @@ public class CenotaphBlockListener implements Listener {
 		}
 
 		if (plugin.lwcPlugin != null && plugin.lwcEnable && tBlock.getLwcEnabled()) {
-			if (tBlock.getOwner().equals(p.getName()) || p.hasPermission("cenotaph.admin")) {
+			if (tBlock.getOwnerUUID().equals(p.getUniqueId()) || p.hasPermission("cenotaph.admin")) {
 				plugin.deactivateLWC(tBlock, true);
 			} else {
 				event.setCancelled(true);
@@ -71,7 +71,7 @@ public class CenotaphBlockListener implements Listener {
 		}
 		
 		if (plugin.LocketteEnable && tBlock.getLocketteSign() != null) {
-			if (!tBlock.getOwner().equals(p.getName()) && !p.hasPermission("cenotaph.admin")) {
+			if (!tBlock.getOwnerUUID().equals(p.getUniqueId()) && !p.hasPermission("cenotaph.admin")) {
 				event.setCancelled(true);
 				plugin.sendMessage(p, "Cannot interfere with a locked Cenotaph.");
 				return;

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphPlayerListener.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphPlayerListener.java
@@ -32,7 +32,7 @@ public class CenotaphPlayerListener implements Listener {
 		TombBlock tBlock = Cenotaph.tombBlockList.get(b.getLocation());
 		if (tBlock == null || !(tBlock.getBlock().getState() instanceof Chest)) return;
 
-		if (!tBlock.getOwner().equals(event.getPlayer().getName())) return;
+		if (!tBlock.getOwnerUUID().equals(event.getPlayer().getUniqueId())) return;
 
 		Chest sChest = (Chest)tBlock.getBlock().getState();
 		Chest lChest = (tBlock.getLBlock() != null) ? (Chest)tBlock.getLBlock().getState() : null;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,7 +6,7 @@ author: Southpaw018
 authors: [cindyker]
 website: http://www.moofit.com
 softdepend: [WorldGuard, Vault, LWC, dynmap]
-api-version: 1.14
+api-version: ${project.bukkitAPIVersion}
 commands:
   cenlist:
     description: Show a list of your Cenotaphs


### PR DESCRIPTION
And also:

Switch over more tombBlock.getOwner() to use townbBlock.getOwnerUUID(),
which will make things play nice when people change their names. May
cause some slight issues when pre 5.1 tombBlocks are quicklooted but it
will be temporary.