### PR TITLE
Add support for MC 1.18 and the increased world depth.

### DIFF
--- a/README
+++ b/README
@@ -121,6 +121,8 @@ LlmDl: I helped with lockette support on earlier versions and did some major cha
 =============
  Changes
 =============
+[Version 6.3]
+  - Add support for MC 1.18 and the increased world depth.
 [Version 6.2]
   - Cleaner solution to the NPE solved in 6.1. (The NPE was tracked down to auto-composting setups and occurs because of incomplete Spigot API.)
 [Version 6.1]

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>MoofIT</groupId>
     <artifactId>Cenotaph</artifactId>
     <packaging>jar</packaging>
-    <version>6.2</version>
+    <version>6.3</version>
     
     <properties>
         <project.bukkitAPIVersion>1.14</project.bukkitAPIVersion>
@@ -45,7 +45,7 @@
         <dependency>
            <groupId>org.spigotmc</groupId>
            <artifactId>spigot-api</artifactId>
-           <version>1.14.4-R0.1-SNAPSHOT</version>
+           <version>1.18-R0.1-SNAPSHOT</version>
            <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/Cenotaph.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/Cenotaph.java
@@ -21,6 +21,8 @@ package com.MoofIT.Minecraft.Cenotaph;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.logging.Logger;
 
 import org.bukkit.World;
@@ -82,6 +84,7 @@ public class Cenotaph extends JavaPlugin {
 	public static Economy econ = null;
 	public static boolean isSpigot = false;
 	public static boolean slimefunEnabled = false;
+	public static Map<World, Integer> worldDepths = new HashMap<>();
 	private String hooked = "";
 
 	@Override
@@ -117,8 +120,10 @@ public class Cenotaph extends JavaPlugin {
 		hologramsEnabled = setupHolograms();
 		slimefunEnabled = setupSlimefun();
 
-		for (World w : getServer().getWorlds())
+		for (World w : getServer().getWorlds()) {
 			CenotaphDatabase.loadTombList(w.getName());
+			setWorldDepth(w);
+		}
 
 		// Start removal timer. Run every 5 seconds (20 ticks per second)
 		if (CenotaphSettings.cenotaphRemove())
@@ -238,6 +243,26 @@ public class Cenotaph extends JavaPlugin {
     	}
     	return false;
     }
+
+	public static void setWorldDepth(World w) {
+		try {
+			setWorldDepth(w, w.getMinHeight());
+		} catch (NoSuchMethodError e) {
+			setWorldDepth(w, 0);
+		}
+	}
+
+	private static void setWorldDepth(World w, int minHeight) {
+		worldDepths.put(w, minHeight);
+	}
+
+	public static boolean hasSetWorldDepth(World w) {
+		return worldDepths.containsKey(w);
+	}
+
+	public static int getWorldDepth(World w) {
+		return worldDepths.get(w);
+	}
 
 	@Override
 	public void onDisable() {

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/Listeners/CenotaphEntityListener.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/Listeners/CenotaphEntityListener.java
@@ -125,7 +125,8 @@ public class CenotaphEntityListener implements Listener {
 		Block block = p.getWorld().getBlockAt(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
 
 		//Don't create the chest if it or its sign would be in the void
-		if (CenotaphSettings.voidCheck() && ((CenotaphSettings.cenotaphSign() && block.getY() > p.getWorld().getMaxHeight() - 1) || (!CenotaphSettings.cenotaphSign() && block.getY() > p.getWorld().getMaxHeight()) || p.getLocation().getY() < 1)) {
+		if (CenotaphSettings.voidCheck() 
+			&& aboveSurface(block.getY(), p.getWorld().getMaxHeight()) || underWorldBottom(loc)) {
 			CenotaphMessaging.sendPrefixedPlayerMessage(p, Lang.string("chest_would_be_in_the_void"));
 			return;
 		}
@@ -321,6 +322,19 @@ public class CenotaphEntityListener implements Listener {
 			if (r.transactionSuccess()){
 				CenotaphMessaging.sendPrefixedPlayerMessage(p, Lang.string("cenotaph_paid_for", CenotaphSettings.cenotaphCost(), Cenotaph.econ.currencyNamePlural()));
 			}
+		}
+	}
+
+	private boolean aboveSurface(int y, int maxHeight) {
+		return CenotaphSettings.cenotaphSign() ? y > maxHeight - 1 : y > maxHeight;
+	}
+
+	private boolean underWorldBottom(Location loc) {
+		try {
+			return loc.getY() < loc.getWorld().getMinHeight();
+		} catch (NoSuchMethodError e) {
+			// Pre 1.18 WorldInfo api doesn't exist, this is a pre-world-height-change server.
+			return loc.getY() < 1;
 		}
 	}
 }

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/Listeners/CenotaphEntityListener.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/Listeners/CenotaphEntityListener.java
@@ -330,11 +330,8 @@ public class CenotaphEntityListener implements Listener {
 	}
 
 	private boolean underWorldBottom(Location loc) {
-		try {
-			return loc.getY() < loc.getWorld().getMinHeight();
-		} catch (NoSuchMethodError e) {
-			// Pre 1.18 WorldInfo api doesn't exist, this is a pre-world-height-change server.
-			return loc.getY() < 1;
-		}
+		if (!Cenotaph.hasSetWorldDepth(loc.getWorld()))
+			Cenotaph.setWorldDepth(loc.getWorld());
+		return loc.getY() < Cenotaph.getWorldDepth(loc.getWorld()) + 1;
 	}
 }


### PR DESCRIPTION
This PR adds support for MC 1.18's Height changes.

Bumps Cenotaph version to 6.3.

VoidCheck was treating under 1 world height as void. This has been extracted out and handled via the new 1.18 World#getMinHeight API, which if not present will fall back to the same formula used in pre-6.3 versions.

