### PR TITLE
Add protection for BlockExplosionEvents to Cenotaphs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>MoofIT</groupId>
     <artifactId>Cenotaph</artifactId>
     <packaging>jar</packaging>
-    <version>6.3</version>
+    <version>6.4</version>
     
     <properties>
         <project.bukkitAPIVersion>1.14</project.bukkitAPIVersion>
@@ -19,12 +19,16 @@
             <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
         </repository>
         <repository>
+            <id>glaremasters repo</id>
+            <url>https://repo.glaremasters.me/repository/towny/</url>
+        </repository>
+        <repository>
             <id>vault-repo</id>
             <url>http://nexus.hc.to/content/repositories/pub_releases</url>
         </repository>
         <repository>
-            <id>sk89q-repo</id>
-            <url>http://maven.sk89q.com/repo/</url>
+            <id>enginehub-maven</id>
+            <url>https://maven.enginehub.org/repo/</url>
         </repository>
         <repository>
             <id>dynamap</id>
@@ -45,13 +49,13 @@
         <dependency>
            <groupId>org.spigotmc</groupId>
            <artifactId>spigot-api</artifactId>
-           <version>1.18-R0.1-SNAPSHOT</version>
+           <version>1.20.4-R0.1-SNAPSHOT</version>
            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>us.dynmap</groupId>
             <artifactId>dynmap-api</artifactId>
-            <version>2.1-SNAPSHOT</version>
+            <version>2.5</version>
         </dependency>
         <dependency>
             <groupId>net.milkbowl.vault</groupId>
@@ -68,7 +72,7 @@
         <dependency>
             <groupId>com.sk89q.worldedit</groupId>
             <artifactId>worldedit-bukkit</artifactId>
-            <version>7.1.0-SNAPSHOT</version>
+            <version>7.2.9</version>
             <scope>provided</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.fusesource.jansi/jansi -->
@@ -90,9 +94,9 @@
   		    <scope>provided</scope>
      	</dependency>
 		<dependency>
-		    <groupId>com.github.TownyAdvanced</groupId>
+		    <groupId>com.palmergames.bukkit.towny</groupId>
 		    <artifactId>Towny</artifactId>
-	    	<version>0.96.2.0</version>
+	    	<version>0.100.1.0</version>
 		    <scope>provided</scope>
 		</dependency>	
     </dependencies>

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphUtil.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/CenotaphUtil.java
@@ -288,7 +288,7 @@ public class CenotaphUtil {
 				mat == Material.SUGAR_CANE ||
 				mat == Material.GRAVEL ||
 				mat == Material.SAND ||
-				mat == Material.GRASS ||
+				mat == Material.SHORT_GRASS ||
 				mat == Material.TALL_GRASS ||
 				(mat.createBlockData() instanceof Ageable) ||
 				(Tag.SMALL_FLOWERS.isTagged(mat) && mat != Material.WITHER_ROSE) ||

--- a/src/main/java/com/MoofIT/Minecraft/Cenotaph/Listeners/CenotaphBlockListener.java
+++ b/src/main/java/com/MoofIT/Minecraft/Cenotaph/Listeners/CenotaphBlockListener.java
@@ -10,12 +10,14 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockBurnEvent;
+import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.block.BlockIgniteEvent;
 import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockPistonRetractEvent;
 import com.MoofIT.Minecraft.Cenotaph.Cenotaph;
 import com.MoofIT.Minecraft.Cenotaph.CenotaphDatabase;
 import com.MoofIT.Minecraft.Cenotaph.CenotaphMessaging;
+import com.MoofIT.Minecraft.Cenotaph.CenotaphSettings;
 import com.MoofIT.Minecraft.Cenotaph.CenotaphUtil;
 import com.MoofIT.Minecraft.Cenotaph.TombBlock;
 import com.MoofIT.Minecraft.Cenotaph.Config.Lang;
@@ -143,5 +145,30 @@ public class CenotaphBlockListener implements Listener {
 		if (!CenotaphUtil.isTombBlock(block))
 			return;
 		CenotaphDatabase.removeTomb(CenotaphUtil.getTombBlock(block), true);
+	}
+
+	@EventHandler
+	public void onBlockExplode(BlockExplodeEvent event) {
+		if (event.isCancelled()) 
+			return;
+		for (Block block : event.blockList()) {
+			if (CenotaphUtil.isTombBlock(block)) {
+				if (CenotaphUtil.getTombBlock(block).isSecured())
+					event.setCancelled(true);
+				else if (CenotaphSettings.explosionProtection())
+					event.setCancelled(true);
+			}
+		}
+	}
+
+	@EventHandler(priority = EventPriority.MONITOR)
+	public void onBlockExplodeMonitor(BlockExplodeEvent event) {
+		if (event.isCancelled()) 
+			return;
+		for (Block block : event.blockList()) {
+			if (CenotaphUtil.isTombBlock(block))
+				if (!event.isCancelled())
+					CenotaphDatabase.removeTomb(CenotaphUtil.getTombBlock(block), true);
+		}
 	}
 }


### PR DESCRIPTION
BlockExplosions are made primarily by Beds and Respawn Anchors, Cenotaphs will be protected from those if it is configured. Matches up with how EntityExplodeEvents are handled.